### PR TITLE
Adjust guest input encoding to match real deployment

### DIFF
--- a/contracts/tests/contract_tests/utils.rs
+++ b/contracts/tests/contract_tests/utils.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use ethers::core::k256::ecdsa::SigningKey;
 use ethers::prelude::*;
 use ethers::utils::{Ganache, GanacheInstance};
-use risc0_zkvm::{serde, Prover, ProverOpts};
+use risc0_zkvm::{Prover, ProverOpts};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -93,8 +93,8 @@ impl BonsaiMock {
                         ProverOpts::default().with_skip_seal(true),
                     )
                     .expect("failed to create prover");
-                    prover.add_input_u32_slice(
-                        &serde::to_vec(submit_request_log.input.deref()).unwrap(),
+                    prover.add_input_u8_slice(
+                        submit_request_log.input.deref(),
                     );
                     prover.run().expect("failed to run guest")
                 };

--- a/methods/guest/src/bin/fibonacci.rs
+++ b/methods/guest/src/bin/fibonacci.rs
@@ -15,10 +15,6 @@
 #![no_main]
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec::Vec;
-
 use ethabi::ethereum_types::U256;
 use ethabi::{ParamType, Token};
 use risc0_zkvm::guest::env;
@@ -34,8 +30,9 @@ fn fibonacci(n: U256) -> U256 {
 }
 
 pub fn main() {
-    // Decode input passed from the application contract by the Bonsai bridge.
-    let input = ethabi::decode_whole(&[ParamType::Uint(256)], &env::read::<Vec<u8>>()).unwrap();
+    // NOTE: Currently env::read_slice requires a length argument. Reading `bytes` or another
+    // dynamically lengthed type will require some work. https://github.com/risc0/risc0/issues/402
+    let input = ethabi::decode_whole(&[ParamType::Uint(256)], env::read_slice(32)).unwrap();
     let n: U256 = input[0].clone().into_uint().unwrap();
 
     // Run the computation.

--- a/methods/src/lib.rs
+++ b/methods/src/lib.rs
@@ -22,7 +22,7 @@ mod tests {
 
     use ethabi::ethereum_types::U256;
     use ethabi::Token;
-    use risc0_zkvm::{serde, Prover, ProverOpts};
+    use risc0_zkvm::{Prover, ProverOpts};
 
     use super::{FIBONACCI_ID, FIBONACCI_PATH};
 
@@ -35,9 +35,7 @@ mod tests {
             ProverOpts::default().with_skip_seal(true),
         )?;
 
-        prover.add_input_u32_slice(&serde::to_vec(&ethabi::encode(&[Token::Uint(
-            U256::from(10),
-        )]))?);
+        prover.add_input_u8_slice(&ethabi::encode(&[Token::Uint(U256::from(10))]));
 
         let receipt = prover.run()?;
 


### PR DESCRIPTION
Input encoding prior to this did not match what is actually used by the current Bonsai
implementation. This PR fixes that and assumes a fixed-length input to the guest.
